### PR TITLE
Add rootfs dir as flag

### DIFF
--- a/.github/workflows/test-sandbox.yml
+++ b/.github/workflows/test-sandbox.yml
@@ -14,14 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Copy repository to /tmp
-        run: |
-          echo "Copying repo to /tmp/castletown..."
-          cp -r "$GITHUB_WORKSPACE" /tmp/castletown
-          echo "good job :p"
-
       - name: Set up dependencies
-        working-directory: /tmp/castletown
         run: |
           sudo apt-get update
           sudo apt-get install -y make
@@ -38,6 +31,7 @@ jobs:
           export PATH=$PATH:/usr/local/go/bin
           go version
 
+          mkdir /tmp/sans
+
       - name: Run sandbox tests
-        working-directory: /tmp/castletown
         run: make test-sandbox

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ prepare-dirs:
 	@sudo mkdir -p /tmp/castletown/images
 	@sudo mkdir -p /tmp/castletown/libcontainer
 	@sudo mkdir -p /tmp/castletown/overlayfs
+	@sudo mkdir -p /tmp/castletown/rootfs
 
 .PHONY: make-rootfs
 make-rootfs: prepare-dirs

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -31,6 +31,7 @@ Don't forget, I'm with you in the dark`,
 		config.ImagesDir, _ = cmd.Flags().GetString("images-dir")
 		config.LibcontainerDir, _ = cmd.Flags().GetString("libcontainer-dir")
 		config.MaxConcurrency, _ = cmd.Flags().GetInt("max-concurrency")
+		config.RootfsDir, _ = cmd.Flags().GetString("rootfs-dir")
 
 		RunServer()
 	},
@@ -39,41 +40,56 @@ Don't forget, I'm with you in the dark`,
 func RunServer() {
 	f, err := os.Stat(config.OverlayFSDir)
 	if os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "OverlayFS path does not exist: %s\n", config.OverlayFSDir)
-		os.Exit(1)
-	}
-	if !f.IsDir() {
+		if err := os.Mkdir(config.OverlayFSDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create OverlayFS directory: %v\n", err)
+			os.Exit(1)
+		}
+	} else if !f.IsDir() {
 		fmt.Fprintf(os.Stderr, "OverlayFS path exists but is not a directory: %s\n", config.OverlayFSDir)
 		os.Exit(1)
 	}
 
 	f, err = os.Stat(config.StorageDir)
 	if os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Storage path does not exist: %s\n", config.StorageDir)
-		os.Exit(1)
-	}
-	if !f.IsDir() {
+		if err := os.Mkdir(config.StorageDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create Storage directory: %v\n", err)
+			os.Exit(1)
+		}
+	} else if !f.IsDir() {
 		fmt.Fprintf(os.Stderr, "Storage path exists but is not a directory: %s\n", config.StorageDir)
 		os.Exit(1)
 	}
 
 	f, err = os.Stat(config.ImagesDir)
 	if os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Images path does not exist: %s\n", config.ImagesDir)
-		os.Exit(1)
-	}
-	if !f.IsDir() {
+		if err := os.Mkdir(config.ImagesDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create Images directory: %v\n", err)
+			os.Exit(1)
+		}
+	} else if !f.IsDir() {
 		fmt.Fprintf(os.Stderr, "Images path exists but is not a directory: %s\n", config.ImagesDir)
 		os.Exit(1)
 	}
 
 	f, err = os.Stat(config.LibcontainerDir)
 	if os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Libcontainer path does not exist: %s\n", config.LibcontainerDir)
+		if err := os.Mkdir(config.LibcontainerDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create Libcontainer directory: %v\n", err)
+			os.Exit(1)
+		}
+	} else if !f.IsDir() {
+		fmt.Fprintf(os.Stderr, "Libcontainer path exists but is not a directory: %s\n", config.LibcontainerDir)
 		os.Exit(1)
 	}
-	if !f.IsDir() {
-		fmt.Fprintf(os.Stderr, "Libcontainer path exists but is not a directory: %s\n", config.LibcontainerDir)
+
+	f, err = os.Stat(config.RootfsDir)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(config.RootfsDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create Rootfs directory: %v\n", err)
+			os.Exit(1)
+		}
+	} else if !f.IsDir() {
+		fmt.Fprintf(os.Stderr, "Rootfs path exists but is not a directory: %s\n", config.RootfsDir)
 		os.Exit(1)
 	}
 
@@ -105,10 +121,12 @@ func init() {
 	// is called directly, e.g.:
 	// serverCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	serverCmd.Flags().IntP("port", "p", 8000, "Port to run the server on")
 	serverCmd.Flags().String("overlayfs-dir", "/tmp/castletown/overlayfs", "Directory for overlayfs directories (i.e. lower, upper, and work directories)")
 	serverCmd.Flags().String("storage-dir", "/tmp/castletown/storage", "Directory for persistent file storage")
 	serverCmd.Flags().String("images-dir", "/tmp/castletown/images", "Directory for container rootfs images")
 	serverCmd.Flags().String("libcontainer-dir", "/tmp/castletown/libcontainer", "Directory for libcontainer containers")
+	serverCmd.Flags().String("rootfs-dir", "/tmp/castletown/rootfs", "Directory for temporary root filesystems")
+
+	serverCmd.Flags().IntP("port", "p", 8000, "Port to run the server on")
 	serverCmd.Flags().Int("max-concurrency", 10, "Maximum number of concurrent sandboxes")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,10 +5,10 @@ var (
 	StorageDir      string
 	ImagesDir       string
 	LibcontainerDir string
+	RootfsDir       string
 
 	MaxConcurrency int
-
-	Port int
+	Port           int
 )
 
 func UseDefaults() {
@@ -16,6 +16,8 @@ func UseDefaults() {
 	StorageDir = "/tmp/castletown/storage"
 	ImagesDir = "/tmp/castletown/images"
 	LibcontainerDir = "/tmp/castletown/libcontainer"
+	RootfsDir = "/tmp/castletown/rootfs"
+
 	MaxConcurrency = 10
 	Port = 8080
 }

--- a/sandbox/spec.go
+++ b/sandbox/spec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/joshjms/castletown/config"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	_ "github.com/opencontainers/cgroups/devices"
@@ -23,6 +24,7 @@ func (s *Sandbox) createSpec() (*specs.Spec, error) {
 			NoNewPrivileges: true,
 		},
 		Root: &specs.Root{
+			Path:     config.RootfsDir,
 			Readonly: false,
 		},
 		Hostname: fmt.Sprintf("castletown-%s", s.id),


### PR DESCRIPTION
Using no option for the `Path` field in `specs.Root` mounts the rootfs at the cwd which might trigger the following error in Github CI or cloud VM environments.

```
remount-private dst=/home/runner/work/castletown/castletown/sandbox, flags=MS_PRIVATE: permission denied
```